### PR TITLE
Feature/bugfix candle controller

### DIFF
--- a/Assets/_Game/Scripts/Candle/CandleController.cs
+++ b/Assets/_Game/Scripts/Candle/CandleController.cs
@@ -140,33 +140,28 @@ public class CandleController : MonoBehaviour
                 anim.SetBool("Red", false);
                 anim.SetBool("Purple", false);
                 anim.SetBool("Blue", false);
-                _candleData = Resources.Load<CandleData>("ScriptableObjects/CandleYellow");
                 break;
             case CandleColor.Red:
                 anim.SetBool("Yellow", false);
                 anim.SetBool("Red", true);
                 anim.SetBool("Purple", false);
                 anim.SetBool("Blue", false);
-                _candleData = Resources.Load<CandleData>("ScriptableObjects/CandleRed");
                 break;
             case CandleColor.Purple:
                 anim.SetBool("Yellow", false);
                 anim.SetBool("Red", false);
                 anim.SetBool("Purple", true);
                 anim.SetBool("Blue", false);
-                _candleData = Resources.Load<CandleData>("ScriptableObjects/CandlePurple");
                 break;
             case CandleColor.Blue:
                 anim.SetBool("Yellow", false);
                 anim.SetBool("Red", false);
                 anim.SetBool("Purple", false);
                 anim.SetBool("Blue", true);
-                _candleData = Resources.Load<CandleData>("ScriptableObjects/CandleBlue");
                 break;
         }
         if (anim != null)
         {
-            anim.runtimeAnimatorController = _candleData.Anim;
             anim.SetInteger("Candlestate", CurrentState);
 
         }

--- a/Assets/_Game/Scripts/Candle/CandleController.cs
+++ b/Assets/_Game/Scripts/Candle/CandleController.cs
@@ -50,7 +50,10 @@ public class CandleController : MonoBehaviour
 
     private void Awake()
     {
-        if(_candleData == null) Debug.LogError("Candle blueprint not assigned.");
+        if(_candleData == null) {
+            Debug.LogWarning("CandleData not assigned. Using default data from Resources...");
+            _candleData = Resources.Load<CandleData>("ScriptableObjects/CandleYellow");
+        }
 
         anim = GetComponent<Animator>();
         if(anim != null) anim.runtimeAnimatorController = _candleData.Anim;


### PR DESCRIPTION
Update candle controller to no longer change runtime animator controller assets when changing colors.

The animator controllers that used to be different colors have been merged into 1 controller to control color changing. We should not be hot-swapping controllers to change colors anymore.